### PR TITLE
Http Connector authenticating to 401 and Login Module expiring state

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,7 +466,6 @@
                         </goals>
                         <phase>validate</phase>
                         <configuration>
-                            <!-- Skipping until we enforce everywhere -->
                             <skip>true</skip>
                         </configuration>
                     </execution>

--- a/resource.address/http/src/main/java/org/kaazing/gateway/resource/address/http/HttpResourceAddress.java
+++ b/resource.address/http/src/main/java/org/kaazing/gateway/resource/address/http/HttpResourceAddress.java
@@ -66,6 +66,8 @@ public final class HttpResourceAddress extends ResourceAddress {
     public static final HttpResourceOption<Boolean> SERVER_HEADER_ENABLED = new HttpServerHeaderOption();
     public static final HttpResourceOption<Collection<Class<? extends Principal>>> REALM_USER_PRINCIPAL_CLASSES = new HttpRealmAuthenticationUserPrincipalClassesOption();
 
+    public static final ResourceOption<Integer> MAX_AUTHENTICATION_ATTEMPTS = new MaxAuthenticationAttemptsOption();
+
     private Boolean serverHeaderEnabled = SERVER_HEADER_ENABLED.defaultValue();
     private Boolean keepAlive = KEEP_ALIVE.defaultValue();
     private Integer httpMaxRedirects = MAXIMUM_REDIRECTS.defaultValue();
@@ -85,6 +87,8 @@ public final class HttpResourceAddress extends ResourceAddress {
     private File tempDirectory;
     private GatewayHttpOriginSecurity gatewayOriginSecurity;
     private Collection<String> balanceOrigins;
+    private Integer maxAuthenticationAttempts;
+    
 
     private String authenticationConnect;
     private String authenticationIdentifier;
@@ -92,6 +96,7 @@ public final class HttpResourceAddress extends ResourceAddress {
     private String serviceDomain;
 
     private Collection<Class<? extends Principal>> realmUserPrincipalClasses;
+
 
 	HttpResourceAddress(ResourceAddressFactorySpi factory, String original, URI resource) {
 		super(factory, original, resource);
@@ -149,6 +154,8 @@ public final class HttpResourceAddress extends ResourceAddress {
                     return (V) serviceDomain;
                 case SERVER_HEADER:
                     return (V) serverHeaderEnabled;
+                case MAX_AUTHENTICATION_ATTEMPTS:
+                    return (V) maxAuthenticationAttempts;
                 case REALM_USER_PRINCIPAL_CLASSES:
                     return (V) realmUserPrincipalClasses;
             }
@@ -235,6 +242,9 @@ public final class HttpResourceAddress extends ResourceAddress {
                 case REALM_USER_PRINCIPAL_CLASSES:
                     realmUserPrincipalClasses = (Collection<Class<? extends Principal>>) value;
                     return;
+                case MAX_AUTHENTICATION_ATTEMPTS:
+                    maxAuthenticationAttempts = (Integer) value;
+                    return;
             }
         }
 
@@ -259,7 +269,7 @@ public final class HttpResourceAddress extends ResourceAddress {
             LOGIN_CONTEXT_FACTORY, INJECTABLE_HEADERS,
             ORIGIN_SECURITY, TEMP_DIRECTORY, GATEWAY_ORIGIN_SECURITY, BALANCE_ORIGINS,
             AUTHENTICATION_CONNECT, AUTHENTICATION_IDENTIFIER, ENCRYPTION_KEY_ALIAS, SERVICE_DOMAIN, SERVER_HEADER,
-            REALM_USER_PRINCIPAL_CLASSES ,MAX_REDIRECTS
+            REALM_USER_PRINCIPAL_CLASSES ,MAX_REDIRECTS, MAX_AUTHENTICATION_ATTEMPTS;
         }
 
         private static final Map<String, ResourceOption<?>> OPTION_NAMES = new HashMap<>();
@@ -287,6 +297,7 @@ public final class HttpResourceAddress extends ResourceAddress {
             super(Kind.KEEP_ALIVE_CONNECTIONS, "keepalive.connections", DEFAULT_HTTP_KEEPALIVE_CONNECTIONS);
         }
     }
+
     private static final class HttpMaxRedirectOption extends HttpResourceOption<Integer> {
         private HttpMaxRedirectOption() {
             super(Kind.MAX_REDIRECTS, "maximum.redirects", 0);
@@ -418,6 +429,12 @@ public final class HttpResourceAddress extends ResourceAddress {
     private static final class HttpRealmAuthenticationUserPrincipalClassesOption extends HttpResourceOption<Collection<Class<? extends Principal>>> {
         private HttpRealmAuthenticationUserPrincipalClassesOption() {
             super(Kind.REALM_USER_PRINCIPAL_CLASSES, "realmAuthenticationUserPrincipalClasses", new ArrayList<>());
+        }
+    }
+ 
+    private static final class MaxAuthenticationAttemptsOption extends HttpResourceOption<Integer> {
+        private MaxAuthenticationAttemptsOption() {
+            super(Kind.MAX_AUTHENTICATION_ATTEMPTS, "max.authentication.attempts", 0);
         }
     }
 

--- a/resource.address/http/src/main/java/org/kaazing/gateway/resource/address/http/HttpResourceAddressFactorySpi.java
+++ b/resource.address/http/src/main/java/org/kaazing/gateway/resource/address/http/HttpResourceAddressFactorySpi.java
@@ -27,9 +27,10 @@ import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.GATE
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.INJECTABLE_HEADERS;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.KEEP_ALIVE;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.KEEP_ALIVE_CONNECTIONS;
-import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAXIMUM_REDIRECTS;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.KEEP_ALIVE_TIMEOUT;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.LOGIN_CONTEXT_FACTORY;
+import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAXIMUM_REDIRECTS;
+import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAX_AUTHENTICATION_ATTEMPTS;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.ORIGIN_SECURITY;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.REALM_AUTHENTICATION_COOKIE_NAMES;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.REALM_AUTHENTICATION_HEADER_NAMES;
@@ -48,7 +49,6 @@ import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.TRAN
 import java.io.File;
 import java.net.URI;
 import java.security.Principal;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -76,7 +76,7 @@ public class HttpResourceAddressFactorySpi extends ResourceAddressFactorySpi<Htt
 
     private static final Map<String, List<ResourceFactory>> RESOURCE_FACTORIES_BY_KEY
             = new HashMap<>();
-
+    
     static {
         // go backwards so we can set alternate addresses correctly
         List<ResourceFactory> insecureAlternateResourceFactories = Collections.singletonList(
@@ -243,6 +243,14 @@ public class HttpResourceAddressFactorySpi extends ResourceAddressFactorySpi<Htt
             options.setOption(REALM_USER_PRINCIPAL_CLASSES, realmUserPrincipalClasses);
         }
 
+        Object maxAuthenticationAttempts = optionsByName.remove(MAX_AUTHENTICATION_ATTEMPTS.name());
+        if (maxAuthenticationAttempts != null) {
+            if (maxAuthenticationAttempts instanceof String) {
+                maxAuthenticationAttempts = Integer.parseInt((String) maxAuthenticationAttempts);
+            }
+            options.setOption(MAX_AUTHENTICATION_ATTEMPTS, (Integer) maxAuthenticationAttempts);
+        }
+
         IdentityResolver httpIdentityResolver = (IdentityResolver) optionsByName.remove(IDENTITY_RESOLVER.name());
         if (httpIdentityResolver != null) {
             options.setOption(IDENTITY_RESOLVER, httpIdentityResolver);
@@ -340,6 +348,7 @@ public class HttpResourceAddressFactorySpi extends ResourceAddressFactorySpi<Htt
         address.setOption0(SERVICE_DOMAIN, options.getOption(SERVICE_DOMAIN));
         address.setOption0(SERVER_HEADER_ENABLED, options.getOption(SERVER_HEADER_ENABLED));
         address.setOption0(REALM_USER_PRINCIPAL_CLASSES, options.getOption(REALM_USER_PRINCIPAL_CLASSES));
+        address.setOption0(MAX_AUTHENTICATION_ATTEMPTS, options.getOption(MAX_AUTHENTICATION_ATTEMPTS));
         if (address.getOption(IDENTITY_RESOLVER) == null) {
              Collection<Class<? extends Principal>> realmUserPrincipalClasses = address.getOption(REALM_USER_PRINCIPAL_CLASSES);
              if (realmUserPrincipalClasses != null && realmUserPrincipalClasses.size() > 0) {

--- a/resource.address/http/src/test/java/org/kaazing/gateway/resource/address/http/HttpResourceAddressFactorySpiTest.java
+++ b/resource.address/http/src/test/java/org/kaazing/gateway/resource/address/http/HttpResourceAddressFactorySpiTest.java
@@ -32,6 +32,7 @@ import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.KEEP
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.KEEP_ALIVE_TIMEOUT;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.LOGIN_CONTEXT_FACTORY;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAXIMUM_REDIRECTS;
+import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAX_AUTHENTICATION_ATTEMPTS;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.REALM_AUTHENTICATION_COOKIE_NAMES;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.REALM_AUTHENTICATION_HEADER_NAMES;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.REALM_AUTHENTICATION_PARAMETER_NAMES;
@@ -95,6 +96,7 @@ public class HttpResourceAddressFactorySpiTest {
         options.put("http.realmAuthenticationCookieNames",new String[] {"c1", "c2"});
         options.put("http.loginContextFactory", loginContextFactory);
         options.put("http.serverHeaderEnabled", Boolean.FALSE);
+        options.put("http.max.authentication.attempts", 5);
 
     }
 
@@ -139,6 +141,7 @@ public class HttpResourceAddressFactorySpiTest {
         assertEmpty(address.getOption(REALM_AUTHENTICATION_COOKIE_NAMES));
         assertNull(address.getOption(LOGIN_CONTEXT_FACTORY));
         assertTrue(address.getOption(SERVER_HEADER_ENABLED));
+        assertEquals(new Integer(0), address.getOption(MAX_AUTHENTICATION_ATTEMPTS));
     }
 
     @Test
@@ -162,6 +165,7 @@ public class HttpResourceAddressFactorySpiTest {
         assertArrayEquals(new String[]{"c1", "c2"}, address.getOption(REALM_AUTHENTICATION_COOKIE_NAMES));
         assertEquals(loginContextFactory, address.getOption(LOGIN_CONTEXT_FACTORY));
         assertFalse(address.getOption(SERVER_HEADER_ENABLED));
+        assertEquals(new Integer(5), address.getOption(MAX_AUTHENTICATION_ATTEMPTS));
     }
 
     @Test

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -51,37 +51,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.11</version>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <configuration>
-                            <encoding>UTF-8</encoding>
-                            <!-- checkstyle doesn't like lambdas and· exceptions 
-                                and bails -->
-                            <consoleOutput>true</consoleOutput>
-                            <failsOnError>true</failsOnError>
-                            <failOnViolation>true</failOnViolation>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.kaazing</groupId>
-                        <artifactId>code.quality</artifactId>
-                        <version>1.1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/security/src/test/java/org/kaazing/gateway/security/auth/SimpleTestLoginModule.java
+++ b/security/src/test/java/org/kaazing/gateway/security/auth/SimpleTestLoginModule.java
@@ -33,13 +33,12 @@ public class SimpleTestLoginModule extends BaseStateDrivenLoginModule {
         try {
             handler.handle(new Callback[] {atc});
         } catch (IOException e) {
-			// TODO: log exception
-			return false;
-		}
-		catch (UnsupportedCallbackException e) {
-			// TODO: log exception
-			return false;
-		}
+            // TODO: log exception
+            return false;
+        } catch (UnsupportedCallbackException e) {
+            // TODO: log exception
+            return false;
+        }
 
         String up = atc.getAuthenticationToken().get();
         String name = up.substring(0, up.indexOf(':'));

--- a/server.api/pom.xml
+++ b/server.api/pom.xml
@@ -37,37 +37,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.11</version>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <configuration>
-                            <encoding>UTF-8</encoding>
-                            <!-- checkstyle doesn't like lambdas and·
-                                 exceptions and bails -->
-                            <consoleOutput>true</consoleOutput>
-                            <failsOnError>true</failsOnError>
-                            <failOnViolation>true</failOnViolation>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.kaazing</groupId>
-                        <artifactId>code.quality</artifactId>
-                        <version>1.1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/server.api/src/main/java/org/kaazing/gateway/server/ExpiringState.java
+++ b/server.api/src/main/java/org/kaazing/gateway/server/ExpiringState.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.server;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ExpiringState is accessible from the @javax.security.auth.spi.LoginModule
+ * via the Map<String,?> options, under the name "ExpiringState".
+ *
+ */
+public interface ExpiringState {
+
+    // TODO remove internally
+    public static final String NAME = "ExpiringState";
+
+    /**
+     * Puts an entry into this map with a given ttl (time to live) value
+     * if the specified key is not already associated with a value.
+     * Entry will expire and get evicted after the ttl.
+     *
+     * @param key      key of the entry
+     * @param value    value of the entry
+     * @param ttl      maximum time for this entry to stay in the map
+     * @param timeunit time unit for the ttl
+     * @return null if absent, or returns the old value of the entry
+     */
+    public abstract Object putIfAbsent(String key, Object value, long ttl, TimeUnit timeunit);
+
+    /**
+     * Gets the given key.
+     *
+     * @param key of the entry
+     * @return value of the entry, or null
+     */
+    public abstract Object get(String key);
+
+    /**
+     * Removes the given key.
+     *
+     * @param key The key of the map entry to remove.
+     * @return A {@link java.util.concurrent.Future} from which the value
+     *         removed from the map can be retrieved.
+     */
+    public abstract Object remove(String key, Object value);
+}

--- a/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultExpiringState.java
+++ b/server/src/main/java/org/kaazing/gateway/server/context/resolve/DefaultExpiringState.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.server.context.resolve;
+
+import java.util.concurrent.TimeUnit;
+
+import org.kaazing.gateway.server.ExpiringState;
+import org.kaazing.gateway.service.messaging.collections.CollectionsFactory;
+
+import com.hazelcast.core.IMap;
+
+final class DefaultExpiringState implements ExpiringState {
+    private final IMap<Object, Object> delegate;
+
+    protected DefaultExpiringState(CollectionsFactory collectionsFactory) {
+        this.delegate = collectionsFactory.getMap(ExpiringState.NAME);
+    }
+
+    @Override
+    public Object putIfAbsent(String key, Object value, long ttl, TimeUnit timeunit) {
+        return delegate.putIfAbsent(key, value);
+    }
+
+    @Override
+    public Object get(String key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public Object remove(String key, Object value) {
+        return delegate.remove(key, value);
+    }
+}

--- a/server/src/main/xsd/gateway-config-201616.xsd
+++ b/server/src/main/xsd/gateway-config-201616.xsd
@@ -1501,6 +1501,16 @@
                     <documentation>The maximum redirects http connector follows</documentation>
                 </annotation>
             </element>
+            <element name="http.max.authentication.attempts" maxOccurs="1" minOccurs="0" type="nonNegativeInteger">
+                <annotation>
+                    <documentation>The maximum responses to a 401 a http connector will make</documentation>
+                </annotation>
+            </element>
+            <element name="http.authenticator" maxOccurs="1" minOccurs="0" type="gateway:CollapsedString">
+                <annotation>
+                    <documentation>The authenticator the http connector should authenticate with</documentation>
+                </annotation>
+            </element>
         </all>
     </complexType>
 

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/DefaultHttpSession.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/DefaultHttpSession.java
@@ -16,7 +16,6 @@
 package org.kaazing.gateway.transport.http;
 
 import static java.lang.String.format;
-import static org.kaazing.gateway.transport.BridgeSession.LOCAL_ADDRESS;
 import static org.kaazing.gateway.transport.http.bridge.filter.HttpProtocolCompatibilityFilter.HttpConditionalWrappedResponseFilter.conditionallyWrappedResponsesRequired;
 import static org.kaazing.gateway.util.InternalSystemProperty.HTTPXE_SPECIFICATION;
 

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpConnector.java
@@ -16,6 +16,7 @@
 package org.kaazing.gateway.transport.http;
 
 import static java.lang.String.format;
+import static java.net.Authenticator.RequestorType.SERVER;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.EnumSet.allOf;
 import static java.util.EnumSet.complementOf;
@@ -23,16 +24,27 @@ import static java.util.EnumSet.of;
 import static org.kaazing.gateway.resource.address.ResourceAddress.NEXT_PROTOCOL;
 import static org.kaazing.gateway.resource.address.ResourceAddress.QUALIFIER;
 import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAXIMUM_REDIRECTS;
+import static org.kaazing.gateway.resource.address.http.HttpResourceAddress.MAX_AUTHENTICATION_ATTEMPTS;
 import static org.kaazing.gateway.transport.BridgeSession.LOCAL_ADDRESS;
 import static org.kaazing.gateway.transport.http.HttpConnectFilter.CONTENT_LENGTH_ADJUSTMENT;
 import static org.kaazing.gateway.transport.http.HttpConnectFilter.PROTOCOL_HTTPXE;
+import static org.kaazing.gateway.transport.http.HttpHeaders.HEADER_AUTHORIZATION;
+import static org.kaazing.gateway.transport.http.HttpHeaders.HEADER_PROXY_AUTHORIZATION;
 import static org.kaazing.gateway.transport.http.HttpUtils.hasCloseHeader;
 import static org.kaazing.gateway.transport.http.bridge.filter.HttpNextProtocolHeaderFilter.PROTOCOL_HTTPXE_1_1;
 import static org.kaazing.gateway.transport.http.bridge.filter.HttpProtocolFilter.PROTOCOL_HTTP_1_1;
+import static org.kaazing.gateway.transport.http.security.auth.WWWAuthenticateHeaderUtils.getChallenges;
+import static org.kaazing.gateway.util.feature.EarlyAccessFeatures.HTTP_AUTHENTICATOR;
 
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.Authenticator.RequestorType;
+import java.net.InetAddress;
+import java.net.PasswordAuthentication;
 import java.net.SocketAddress;
+import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -69,6 +81,7 @@ import org.kaazing.gateway.transport.http.bridge.HttpMessage;
 import org.kaazing.gateway.transport.http.bridge.HttpResponseMessage;
 import org.kaazing.gateway.transport.http.bridge.filter.HttpBuffer;
 import org.kaazing.gateway.transport.http.bridge.filter.HttpBufferAllocator;
+import org.kaazing.gateway.transport.http.security.auth.WWWAuthChallenge;
 import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 import org.kaazing.mina.core.buffer.IoBufferEx;
 import org.kaazing.mina.core.service.IoProcessorEx;
@@ -79,13 +92,13 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
     private static final TypedAttributeKey<HttpConnectSessionFactory> HTTP_SESSION_FACTORY_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSessionFactory");
     public static final TypedAttributeKey<DefaultHttpSession> HTTP_SESSION_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpSession");
     private static final TypedAttributeKey<ConnectFuture> HTTP_CONNECT_FUTURE_KEY = new TypedAttributeKey<>(HttpConnector.class, "httpConnectFuture");
-
+    private Properties configuration;
+    
     private final Map<String, Set<HttpConnectFilter>> connectFiltersByProtocol;
     private final Set<HttpConnectFilter> allConnectFilters;
     private BridgeServiceFactory bridgeServiceFactory;
     ResourceAddressFactory addressFactory;
     private final PersistentConnectionPool persistentConnectionsStore;
-    Properties configuration;
 
     public HttpConnector() {
         super(new DefaultIoSessionConfigEx());
@@ -99,6 +112,11 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         this.persistentConnectionsStore = new PersistentConnectionPool(logger);
     }
 
+    @Resource(name = "configuration")
+    public void setConfiguration(Properties configuration) {
+        this.configuration = configuration;
+    }
+
     @Resource(name = "bridgeServiceFactory")
     public void setBridgeServiceFactory(BridgeServiceFactory bridgeServiceFactory) {
         this.bridgeServiceFactory = bridgeServiceFactory;
@@ -107,11 +125,6 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
     @Resource(name = "resourceAddressFactory")
     public void setResourceAddressFactory(ResourceAddressFactory resourceAddressFactory) {
         this.addressFactory = resourceAddressFactory;
-    }
-
-    @Resource(name = "configuration")
-    public void setConfiguration(Properties configuration) {
-        this.configuration = configuration;
     }
 
     @Override
@@ -130,10 +143,10 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
     }
 
     @Override
-    protected <T extends ConnectFuture> ConnectFuture connectInternal(final ResourceAddress address,
-                final IoHandler handler, final IoSessionInitializer<T> initializer) {
+    protected <T extends ConnectFuture> ConnectFuture connectInternal(final ResourceAddress address, final IoHandler handler,
+        final IoSessionInitializer<T> initializer) {
 
-        final ConnectFuture connectFuture =  new DefaultConnectFuture();
+        final ConnectFuture connectFuture = new DefaultConnectFuture();
         final ResourceAddress transportAddress = address.getTransport();
 
         // initializer for bridge session to specify bridge handler,
@@ -232,7 +245,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
             switch (filter) {
             case CODEC:
                 // Note: we MUST NOT remove the codec filter until
-                //       after the first IoBuffer is received post-upgrade
+                // after the first IoBuffer is received post-upgrade
                 break;
             default:
                 removeFilter(filterChain, filter.filterName());
@@ -244,8 +257,8 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
 
     @Override
     protected void finishSessionInitialization0(IoSession session, IoFuture future) {
-        DefaultHttpSession httpSession = (DefaultHttpSession)session;
-        HttpConnectProcessor processor = (HttpConnectProcessor)httpSession.getProcessor();
+        DefaultHttpSession httpSession = (DefaultHttpSession) session;
+        HttpConnectProcessor processor = (HttpConnectProcessor) httpSession.getProcessor();
         processor.finishConnect(httpSession);
     }
 
@@ -258,9 +271,6 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         };
     }
 
-
-    // initializer for bridge session to specify bridge handler,
-    // and call user-defined bridge session initializer if present
     private <T extends ConnectFuture> IoSessionInitializer<T> createHttpSessionInitializer(final IoHandler handler, final IoSessionInitializer<T> initializer) {
         return (session, future) -> {
             DefaultHttpSession httpSession = (DefaultHttpSession) session;
@@ -304,7 +314,6 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
                 if (connectionClose && !httpSession.isClosing()) {
                     httpSession.getProcessor().remove(httpSession);
                 }
-
                 if (!session.isClosing()) {
                     IoFilterChain filterChain = session.getFilterChain();
                     removeBridgeFilters(filterChain);
@@ -313,15 +322,13 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         }
 
         @Override
-        protected void doExceptionCaught(IoSessionEx session, Throwable cause)
-                throws Exception {
+        protected void doExceptionCaught(IoSessionEx session, Throwable cause) throws Exception {
             if (logger.isDebugEnabled()) {
                 String message = format("Error on HTTP connection attempt: %s", cause);
                 if (logger.isTraceEnabled()) {
                     // note: still debug level, but with extra detail about the exception
                     logger.debug(message, cause);
-                }
-                else {
+                } else {
                     logger.debug(message);
                 }
             }
@@ -335,8 +342,7 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         }
 
         @Override
-        protected void doSessionIdle(IoSessionEx session, IdleStatus status)
-                throws Exception {
+        protected void doSessionIdle(IoSessionEx session, IdleStatus status) throws Exception {
             // TODO Auto-generated method stub
             super.doSessionIdle(session, status);
         }
@@ -351,8 +357,9 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
 
             switch (httpMessage.getKind()) {
             case RESPONSE:
-                HttpResponseMessage httpResponse = (HttpResponseMessage)httpMessage;
+                HttpResponseMessage httpResponse = (HttpResponseMessage) httpMessage;
                 HttpStatus httpStatus = httpResponse.getStatus();
+
                 httpSession.setStatus(httpStatus);
                 httpSession.setReason(httpResponse.getReason());
                 httpSession.setVersion(httpResponse.getVersion());
@@ -392,6 +399,19 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
                 case REDIRECT_NOT_MODIFIED:
                     httpSession.close(false);
                     break;
+                case CLIENT_UNAUTHORIZED:
+                    String authenticate = getAuthentication(httpSession, (HttpResponseMessage) httpMessage, SERVER);
+                    if (authenticate != null) {
+                        authenticate(httpSession, session, authenticate, SERVER);
+                    }else{
+                        HttpContentMessage httpContent = httpResponse.getContent();
+                        if (httpContent == null) {
+                            IoBufferAllocatorEx<? extends HttpBuffer> allocator = httpSession.getBufferAllocator();
+                            httpContent = new HttpContentMessage(allocator.wrap(allocator.allocate(0)), true);
+                        }
+                        fireContentReceived(httpSession, httpContent);
+                    }
+                    break;
                 default:
                     HttpContentMessage httpContent = httpResponse.getContent();
                     if (httpContent == null) {
@@ -426,15 +446,105 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
             return redirctBehavior != null && redirctBehavior > 0;
         }
 
+
+        /**
+         * Gets the password Authentication header value
+         * @param httpSession
+         * @param httpMessage
+         * @param requestorType
+         * @return
+         */
+        String getAuthentication(DefaultHttpSession httpSession,
+            HttpResponseMessage httpMessage, RequestorType requestorType) {
+            Integer maxAthenticates = new Integer((httpSession.getRemoteAddress().getOption(MAX_AUTHENTICATION_ATTEMPTS)));
+            String result = null;
+            if (maxAthenticates > 0 && HTTP_AUTHENTICATOR.isEnabled(configuration)) {
+                try {
+                    ResourceAddress remoteAddress = httpSession.getRemoteAddress();
+                    final URI remoteURI = remoteAddress.getResource();
+                    List<WWWAuthChallenge> challenges =
+                            getChallenges(httpMessage.getHeader(HttpHeaders.HEADER_WWW_AUTHENTICATE));
+                    for (WWWAuthChallenge challenge : challenges) {
+                        // @formatter:off
+                        String scheme = challenge.getScheme();
+                        PasswordAuthentication credentials = Authenticator.requestPasswordAuthentication(
+                                remoteURI.getHost(),
+                                InetAddress.getByName(remoteURI.getHost()),
+                                remoteURI.getPort(),
+                                "HTTP",
+                                challenge.getChallenge().replaceFirst(scheme + " ", ""),
+                                scheme,
+                                remoteURI.toURL(),
+                                requestorType);
+                        // @formatter:on
+                        result = WWWAuthChallenge.encodeAuthorizationHeader(scheme, credentials);
+                        if (result != null) {
+                            break;
+                        }
+                    }
+                } catch (Exception e) {
+                    if (logger.isWarnEnabled()) {
+                        logger.warn("Failed to get a valid response from Authenticator due to exception ", e);
+                    }
+                }
+            }
+            return result;
+        }
+
+        /**
+         * Attempts authentication to a http address.
+         * @param httpSession
+         * @param session
+         * @param challengeToCredentials
+         * @param proxy
+         * @return
+         */
+        private DefaultConnectFuture authenticate(DefaultHttpSession httpSession, IoSessionEx session, String authorizationValue,
+            RequestorType requestorType) {
+            String location = httpSession.getRemoteAddress().getExternalURI();
+            HashMap<ResourceOption<?>, Object> overrides = new HashMap<>();
+            Integer maxAthenticates = new Integer((httpSession.getRemoteAddress().getOption(MAX_AUTHENTICATION_ATTEMPTS)) - 1);
+            overrides.put(MAX_AUTHENTICATION_ATTEMPTS, maxAthenticates);
+            ResourceAddress newConnectAddress = addressFactory.newResourceAddress(location.replaceFirst("ws", "http"),
+                    new WrappedResourceOptionsForConnectionRetry(httpSession, overrides));
+            if (RequestorType.SERVER.equals(requestorType)) {
+                httpSession.setWriteHeader(HEADER_AUTHORIZATION, authorizationValue);
+            } else {
+                httpSession.setWriteHeader(HEADER_PROXY_AUTHORIZATION, authorizationValue);
+            }
+            return retryConnect(httpSession, session, newConnectAddress);
+        }
+
+        /**
+         * Follows a redirect.
+         * @param httpSession
+         * @param session
+         * @return
+         */
         private DefaultConnectFuture followRedirect(DefaultHttpSession httpSession, IoSessionEx session) {
+            HashMap<ResourceOption<?>, Object> overrides = new HashMap<>();
             String location = httpSession.getReadHeader("location");
+            Integer maxRedirects = new Integer((httpSession.getRemoteAddress().getOption(MAXIMUM_REDIRECTS)) - 1);
+            overrides.put(MAXIMUM_REDIRECTS, maxRedirects);
             ResourceAddress newConnectAddress =
-                    addressFactory.newResourceAddress(location.replaceFirst("ws","http"), new HttpRedirectResourceOptions(httpSession));
+                    addressFactory.newResourceAddress(location.replaceFirst("ws","http"), new WrappedResourceOptionsForConnectionRetry(httpSession, overrides));
+            return retryConnect(httpSession, session, newConnectAddress);
+        }
+
+        /**
+         * Retries a connect based on new ConnectAddress
+         * @param httpSession
+         * @param session
+         * @param newConnectAddress
+         * @return
+         */
+        private DefaultConnectFuture retryConnect(DefaultHttpSession httpSession, IoSessionEx session,
+            ResourceAddress newConnectAddress) {
             DefaultConnectFuture connectFuture = new DefaultConnectFuture();
             HTTP_SESSION_KEY.remove(session);
             connectFuture.addListener(future -> session.close(false));
             httpSession.setRemoteAddress(newConnectAddress);
-            final HttpConnectSessionFactory httpSessionFactory = new HttpRedirectSessionFactory(httpSession);
+            final HttpConnectSessionFactory httpSessionFactory = new HttpRetryConnectSessionFactory(httpSession);
             connectInternal0(connectFuture, newConnectAddress, httpSessionFactory);
             return connectFuture;
         }
@@ -453,11 +563,13 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         }
     };
 
-    private final class HttpRedirectResourceOptions implements ResourceOptions {
+    private final class WrappedResourceOptionsForConnectionRetry implements ResourceOptions {
         private final DefaultHttpSession httpSession;
+        private final Map<ResourceOption<?>, Object> optionOverrides;
 
-        public HttpRedirectResourceOptions(DefaultHttpSession httpSession) {
+        public WrappedResourceOptionsForConnectionRetry(DefaultHttpSession httpSession, HashMap<ResourceOption<?>, Object>  overrides) {
             this.httpSession = httpSession;
+            this.optionOverrides = overrides;
         }
 
         @Override
@@ -481,24 +593,22 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
                     || ResourceAddress.TRANSPORTED_URI.equals(key)) {
                 return null;
             }
-            if (HttpResourceAddress.MAXIMUM_REDIRECTS.equals(key)) {
-                return (T) new Integer(((Integer) httpSession.getRemoteAddress().getOption(key)) - 1);
-            }
-            return httpSession.getRemoteAddress().getOption(key);
+            Object override = optionOverrides.get(key);
+            return override != null ? (T) override : httpSession.getRemoteAddress().getOption(key);
         }
     }
 
 
     class DefaultHttpConnectSessionFactory implements HttpConnectSessionFactory {
 
-        private final HttpConnector httpConnectSessionFactory;
+        private final HttpConnector httpConnector;
         private final ResourceAddress connectAddress;
         private final IoSessionInitializer<? extends IoFuture> httpSessionInitializer;
         private final IoFuture connectFuture;
 
         public DefaultHttpConnectSessionFactory(HttpConnector httpConnector, ResourceAddress connectAddress,
                 IoSessionInitializer<? extends IoFuture> httpSessionInitializer, ConnectFuture connectFuture) {
-            httpConnectSessionFactory = httpConnector;
+            this.httpConnector = httpConnector;
             this.connectAddress = connectAddress;
             this.httpSessionInitializer = httpSessionInitializer;
             this.connectFuture = connectFuture;
@@ -508,18 +618,18 @@ public class HttpConnector extends AbstractBridgeConnector<DefaultHttpSession> {
         public DefaultHttpSession get(IoSession parent) throws Exception {
             ResourceAddress transportAddress = LOCAL_ADDRESS.get(parent);
             final ResourceAddress localAddress =
-                    httpConnectSessionFactory.addressFactory.newResourceAddress(connectAddress, transportAddress);
+                    httpConnector.addressFactory.newResourceAddress(connectAddress, transportAddress);
             Callable<DefaultHttpSession> httpSessionFactory = () -> {
                 IoSessionEx parentEx = (IoSessionEx) parent;
                 IoBufferAllocatorEx<?> parentAllocator = parentEx.getBufferAllocator();
-                DefaultHttpSession httpSession = new DefaultHttpSession(httpConnectSessionFactory,
-                        httpConnectSessionFactory.getProcessor(), localAddress, connectAddress, parentEx,
-                        new HttpBufferAllocator(parentAllocator), httpConnectSessionFactory.configuration);
-                parent.setAttribute(HttpConnector.HTTP_SESSION_KEY, httpSession);
+                DefaultHttpSession httpSession = new DefaultHttpSession(httpConnector,
+                        httpConnector.getProcessor(), localAddress, connectAddress, parentEx,
+                        new HttpBufferAllocator(parentAllocator), httpConnector.configuration);
+                parent.setAttribute(HTTP_SESSION_KEY, httpSession);
                 return httpSession;
             };
 
-            return httpConnectSessionFactory.newSession(httpSessionInitializer, connectFuture, httpSessionFactory);
+            return httpConnector.newSession(httpSessionInitializer, connectFuture, httpSessionFactory);
         }
     }
 }

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpHeaders.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpHeaders.java
@@ -18,6 +18,7 @@ package org.kaazing.gateway.transport.http;
 public interface HttpHeaders {
 
     String HEADER_AUTHORIZATION = "Authorization";
+    String HEADER_PROXY_AUTHORIZATION = "Proxy-Authorization";
     String HEADER_CONTENT_LENGTH = "Content-Length";
     String HEADER_CONTENT_TYPE = "Content-Type";
     String HEADER_DATE = "Date";
@@ -45,5 +46,6 @@ public interface HttpHeaders {
     String HEADER_X_SEQUENCE_NO = "X-Sequence-No";
     String HEADER_SET_COOKIE = "Set-Cookie";
     String HEADER_LOCATION = "Location";
+    String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
 
 }

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpRetryConnectSessionFactory.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/HttpRetryConnectSessionFactory.java
@@ -23,11 +23,11 @@ import org.kaazing.mina.core.session.IoSessionEx;
  * Session factory used when HttpConnector is following a redirect
  *
  */
-class HttpRedirectSessionFactory implements HttpConnectSessionFactory {
+class HttpRetryConnectSessionFactory implements HttpConnectSessionFactory {
 
     private final DefaultHttpSession httpSession;
 
-    public HttpRedirectSessionFactory(DefaultHttpSession httpSession) {
+    public HttpRetryConnectSessionFactory(DefaultHttpSession httpSession) {
         this.httpSession = httpSession;
     }
 

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/security/auth/WWWAuthChallenge.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/security/auth/WWWAuthChallenge.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.http.security.auth;
+
+import static java.lang.String.format;
+
+import java.net.PasswordAuthentication;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WWWAuthChallenge {
+
+    static final String TYPE_GROUP_NAME = "scheme";
+    static final String REALM_GROUP_NAME = "realm";
+    static final Pattern SCHEME_PATTERN =
+            Pattern.compile(format("(?<%s>[a-zA-Z_]+) realm=\"(?<%s>[^\"]+)\".*", TYPE_GROUP_NAME, REALM_GROUP_NAME));
+    protected static final String[] SUPPORTED_SCHEMES = new String[]{"basic", "digest"};
+
+    private final String challenge;
+    private final String realm;
+    private final String type;
+
+    public WWWAuthChallenge(String challenge) {
+        this.challenge = challenge;
+        Matcher matcher = SCHEME_PATTERN.matcher(challenge);
+        matcher.matches();
+        this.realm = matcher.group(REALM_GROUP_NAME);
+        this.type = matcher.group(TYPE_GROUP_NAME);
+    }
+
+    public String getChallenge() {
+        return challenge;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public String getScheme() {
+        return type;
+    }
+
+    public static String[] getSupportedSchemes() {
+        return SUPPORTED_SCHEMES;
+    }
+
+    public static String encodeAuthorizationHeader(String scheme, PasswordAuthentication value) {
+        if(value == null){
+            return null;
+        }else if("basic".equalsIgnoreCase(scheme)){
+            // https://tools.ietf.org/html/rfc7617
+            char[] pwd = value.getPassword();
+            String encodedBytes = Base64.getEncoder().encodeToString((value.getUserName() + ":" + new String(pwd)).getBytes());
+            Arrays.fill(pwd, ' ');
+            return "Basic " + encodedBytes;
+        }
+        return null;
+    }
+
+}

--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/security/auth/WWWAuthenticateHeaderUtils.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/security/auth/WWWAuthenticateHeaderUtils.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.http.security.auth;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class WWWAuthenticateHeaderUtils {
+
+    private WWWAuthenticateHeaderUtils() {
+        // Utility class
+    }
+
+    static String[] splitWWWAuthenticateHeaderBySchemes(String headerValue) {
+        return headerValue.split(",\\s(?=[^\\s]+\\srealm=)");
+    }
+
+    public static List<WWWAuthChallenge> getChallenges(String headerValue) {
+        List<WWWAuthChallenge> challenges = new ArrayList<>();
+        for (String challenge : splitWWWAuthenticateHeaderBySchemes(headerValue)) {
+            challenges.add(new WWWAuthChallenge(challenge));
+        }
+        return challenges;
+    }
+
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpConnectorRule.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/HttpConnectorRule.java
@@ -18,6 +18,7 @@ package org.kaazing.gateway.transport.http;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.mina.core.future.ConnectFuture;
 import org.apache.mina.core.service.IoHandler;
@@ -45,21 +46,23 @@ public class HttpConnectorRule implements TestRule {
     private ResourceAddressFactory addressFactory;
     private HttpConnector httpConnector;
     private Map<String, Object> connectOptions = new HashMap<>();
+    private final Properties props = new Properties();
 
     @Override
     public Statement apply(Statement base, Description description) {
         return new ConnectorStatement(base);
     }
 
-    public ConnectFuture connect(String connect, IoHandler connectHandler, IoSessionInitializer<? extends ConnectFuture> initializer) {
+    public ConnectFuture connect(String connect, IoHandler connectHandler, IoSessionInitializer<? extends ConnectFuture> initializer, Map<String, Object> connectOptions) {
         ResourceAddress connectAddress =
                 addressFactory.newResourceAddress(connect, getConnectOptions());
 
         return httpConnector.connect(connectAddress, connectHandler, initializer);
     }
 
-    public Map<String, Object> getConnectOptions() {
-        return connectOptions;
+    public ConnectFuture connect(String connect, IoHandler connectHandler, IoSessionInitializer<? extends ConnectFuture> initializer) {
+        Map<String, Object> connectOptions = new HashMap<>();
+        return this.connect(connect, connectHandler, initializer, connectOptions);
     }
 
     private final class ConnectorStatement extends Statement {
@@ -98,6 +101,8 @@ public class HttpConnectorRule implements TestRule {
                 httpConnector.setBridgeServiceFactory(serviceFactory);
                 httpConnector.setResourceAddressFactory(addressFactory);
 
+                httpConnector.setConfiguration(props);
+
                 base.evaluate();
             } finally {
                 tcpConnector.dispose();
@@ -107,5 +112,14 @@ public class HttpConnectorRule implements TestRule {
             }
         }
 
+    }
+
+    public Map<String, Object> getConnectOptions() {
+        return connectOptions;
+    }
+
+    public HttpConnectorRule addProperty(String key, String value) {
+        props.put(key, value);
+        return this;
     }
 }

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/jmsBalancerIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/jmsBalancerIT.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.transport.http;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import org.apache.mina.core.future.ConnectFuture;
+import org.apache.mina.core.service.IoHandler;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.core.session.IoSessionInitializer;
+import org.jmock.Mockery;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.transport.http.HttpConnectSession;
+import org.kaazing.gateway.transport.http.HttpMethod;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+@Ignore
+public class jmsBalancerIT {
+
+    private final HttpConnectorRule connector = new HttpConnectorRule();
+    private final K3poRule k3po = new K3poRule();
+    @Rule
+    public TestRule chain = createRuleChain(connector, k3po);
+    private Mockery context;
+
+    @Before
+    public void initialize() {
+        context = new Mockery();
+    }
+
+    @Test
+    @Specification("should.receive.redirect.response")
+    public void responseMustBeARedirect() throws Exception {
+        final IoHandler handler = context.mock(IoHandler.class);
+        ConnectFuture connectFuture = connector.connect("http://localhost:8080/jms", handler,
+                new ConnectSessionInitializer());
+        connectFuture.awaitUninterruptibly();
+        assertTrue(connectFuture.isConnected());
+
+        k3po.finish();
+    }
+
+    private static class ConnectSessionInitializer implements IoSessionInitializer<ConnectFuture> {
+        @Override
+        public void initializeSession(IoSession session, ConnectFuture future) {
+            HttpConnectSession connectSession = (HttpConnectSession) session;
+            connectSession.setMethod(HttpMethod.GET);
+            connectSession.addWriteHeader("Upgrade", "websocket");
+            connectSession.addWriteHeader("Sec-WebSocket-Version" , "13");
+            connectSession.addWriteHeader("Sec-WebSocket-Key" , "dGhlIHNhbXBsZSBub25jZQ==");
+            connectSession.addWriteHeader("Connection", "Upgrade");
+        }
+    }
+
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/WWWAuthenticateHeaderUtilsTest.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/WWWAuthenticateHeaderUtilsTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.http.security.auth;
+
+import static org.kaazing.gateway.transport.http.security.auth.WWWAuthenticateHeaderUtils.getChallenges;
+import static org.kaazing.gateway.transport.http.security.auth.WWWAuthenticateHeaderUtils.splitWWWAuthenticateHeaderBySchemes;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WWWAuthenticateHeaderUtilsTest {
+
+    private static final String SINGLE_TYPE_WWW_AUTH_HEADER = "Basic realm=\"factor1\"";
+    private static final String SINGLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS =
+            "Newauth realm=\"apps\", type=1, title=\"Login to \\\"apps\\\"";
+    private static final String MULTIPLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS =
+            "Newauth realm=\"apps\", type=1, title=\"Login to \\\"apps\\\"\", Basic realm=\"simple\"";
+
+    @Test
+    public void getChallengeFromSingleWWWAuthHeader() {
+        // single value
+        String[] result = splitWWWAuthenticateHeaderBySchemes(SINGLE_TYPE_WWW_AUTH_HEADER);
+        Assert.assertEquals(1, result.length);
+        Assert.assertEquals(SINGLE_TYPE_WWW_AUTH_HEADER, result[0]);
+
+        WWWAuthChallenge challenge = new WWWAuthChallenge(result[0]);
+        Assert.assertEquals("Basic", challenge.getScheme());
+        Assert.assertEquals("factor1", challenge.getRealm());
+        Assert.assertEquals(SINGLE_TYPE_WWW_AUTH_HEADER, challenge.getChallenge());
+    }
+
+    @Test
+    public void getChallengeFromSingleWWWAuthHeaderWithParams() {
+        String[] result = splitWWWAuthenticateHeaderBySchemes(SINGLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS);
+        Assert.assertEquals(1, result.length);
+        Assert.assertEquals(SINGLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS, result[0]);
+
+        WWWAuthChallenge challenge = new WWWAuthChallenge(result[0]);
+        Assert.assertEquals("Newauth", challenge.getScheme());
+        Assert.assertEquals("apps", challenge.getRealm());
+        Assert.assertEquals(SINGLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS, challenge.getChallenge());
+    }
+
+    @Test
+    public void getChallengeFromMultipleWWWAuthHeader() {
+        String[] result = splitWWWAuthenticateHeaderBySchemes(MULTIPLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS);
+        Assert.assertEquals(2, result.length);
+        final String expectedChallenge1 = "Newauth realm=\"apps\", type=1, title=\"Login to \\\"apps\\\"\"";
+        final String expectedChallenge2 = "Basic realm=\"simple\"";
+        Assert.assertEquals(expectedChallenge1, result[0]);
+        Assert.assertEquals(expectedChallenge2, result[1]);
+
+        WWWAuthChallenge challenge = new WWWAuthChallenge(result[0]);
+        Assert.assertEquals("Newauth", challenge.getScheme());
+        Assert.assertEquals("apps", challenge.getRealm());
+        Assert.assertEquals(expectedChallenge1, challenge.getChallenge());
+        challenge = new WWWAuthChallenge(result[1]);
+        Assert.assertEquals("Basic", challenge.getScheme());
+        Assert.assertEquals("simple", challenge.getRealm());
+        Assert.assertEquals(expectedChallenge2, challenge.getChallenge());
+    }
+
+    @Test
+    public void getChallengesFromMultipleWWWAuthHeader() {
+        final String expectedChallenge1 = "Newauth realm=\"apps\", type=1, title=\"Login to \\\"apps\\\"\"";
+        final String expectedChallenge2 = "Basic realm=\"simple\"";
+
+        List<WWWAuthChallenge> result = getChallenges(MULTIPLE_TYPE_WWW_AUTH_HEADER_WITH_PARAMS);
+
+        WWWAuthChallenge challenge = result.get(0);
+        Assert.assertEquals("Newauth", challenge.getScheme());
+        Assert.assertEquals("apps", challenge.getRealm());
+        Assert.assertEquals(expectedChallenge1, challenge.getChallenge());
+        challenge = result.get(1);
+        Assert.assertEquals("Basic", challenge.getScheme());
+        Assert.assertEquals("simple", challenge.getRealm());
+        Assert.assertEquals(expectedChallenge2, challenge.getChallenge());
+    }
+
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/connector/AuthenticatorIT.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/connector/AuthenticatorIT.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.transport.http.security.auth.connector;
+
+import static java.net.Authenticator.setDefault;
+import static org.kaazing.gateway.transport.http.HttpMethod.GET;
+import static org.kaazing.gateway.transport.http.HttpStatus.CLIENT_UNAUTHORIZED;
+import static org.kaazing.gateway.transport.http.HttpStatus.SUCCESS_OK;
+import static org.kaazing.gateway.util.feature.EarlyAccessFeatures.HTTP_AUTHENTICATOR;
+import static org.kaazing.test.util.ITUtil.createRuleChain;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.mina.core.future.ConnectFuture;
+import org.apache.mina.core.service.IoHandler;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.core.session.IoSessionInitializer;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.States;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.kaazing.gateway.transport.http.HttpConnectSession;
+import org.kaazing.gateway.transport.http.HttpConnectorRule;
+import org.kaazing.gateway.transport.http.HttpSession;
+import org.kaazing.gateway.transport.http.HttpStatus;
+import org.kaazing.k3po.junit.annotation.Specification;
+import org.kaazing.k3po.junit.rules.K3poRule;
+import org.kaazing.mina.core.buffer.IoBufferEx;
+
+public class AuthenticatorIT {
+
+    private final HttpConnectorRule connector = new HttpConnectorRule().addProperty(HTTP_AUTHENTICATOR.getPropertyName(), "true");
+    private final K3poRule k3po = new K3poRule();
+    private States testState;
+
+    @Rule
+    public TestRule chain = createRuleChain(connector, k3po);
+
+    @Rule
+    public ResetAuthenticatorRule resetAuthenticatorRule = new ResetAuthenticatorRule();
+
+    AuthenticatorMock authenticator;
+    private Mockery context;
+
+    Synchroniser syncronizer;
+
+    public abstract class AuthenticatorMock extends Authenticator {
+        public abstract PasswordAuthentication getPasswordAuthentication();
+    }
+
+    @Before
+    public void initialize() {
+        context = new Mockery() {
+            {
+                setImposteriser(ClassImposteriser.INSTANCE);
+            }
+        };
+        testState = context.states("testState").startsAs("initial-state");
+        syncronizer = new Synchroniser();
+        context.setThreadingPolicy(syncronizer);
+        authenticator = context.mock(AuthenticatorMock.class);
+        // inner class this
+        setDefault(authenticator);
+    }
+
+    @After
+    public void after() {
+        context.assertIsSatisfied();
+    }
+
+    private SessionWithStatus withHttpSessionOfStatus(HttpStatus status) {
+        return new SessionWithStatus(status);
+    }
+
+    private class SessionWithStatus extends BaseMatcher<HttpSession> {
+
+        private HttpStatus status;
+
+        public SessionWithStatus(HttpStatus status) {
+            this.status = status;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            return item instanceof HttpSession && status.equals(((HttpSession) item).getStatus());
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("Matches HttpSession with status " + status);
+        }
+    }
+
+    @Specification("basic.challenge")
+    @Test
+    public void basicChallenge() throws Exception {
+        connector.getConnectOptions().put("http.max.authentication.attempts", "0");
+        final IoHandler handler = context.mock(IoHandler.class);
+        context.checking(new Expectations() {
+            {
+                oneOf(handler).sessionCreated(with(any(IoSession.class)));
+                oneOf(handler).sessionOpened(with(any(IoSession.class)));
+                oneOf(handler).messageReceived(with(withHttpSessionOfStatus(CLIENT_UNAUTHORIZED)), with(any(IoBufferEx.class)));
+                oneOf(handler).sessionClosed(with(any(IoSession.class)));
+                then(testState.is("finished"));
+            }
+        });
+        Map<String, Object> connectOptions = new HashMap<>();
+        connector.connect("http://localhost:8080/resource", handler, new IoSessionInitializer<ConnectFuture>() {
+            @Override
+            public void initializeSession(IoSession session, ConnectFuture future) {
+                HttpConnectSession connectSession = (HttpConnectSession) session;
+                connectSession.setMethod(GET);
+            }
+        }, connectOptions);
+
+        k3po.finish();
+        syncronizer.waitUntil(testState.is("finished"));
+    }
+
+    @Specification("basic.challenge.and.accept")
+    @Test
+    public void basicChallengeAndAccept() throws Exception {
+        connector.getConnectOptions().put("http.max.authentication.attempts", "1");
+        final IoHandler handler = context.mock(IoHandler.class);
+        context.checking(new Expectations() {
+            {
+                oneOf(handler).sessionCreated(with(any(IoSession.class)));
+                oneOf(handler).sessionOpened(with(any(IoSession.class)));
+                oneOf(authenticator).getPasswordAuthentication();
+                will(returnValue(new PasswordAuthentication("joe", new char[]{'w', 'e', 'l', 'c', 'o', 'm', 'e'})));
+                oneOf(handler).messageReceived(with(withHttpSessionOfStatus(SUCCESS_OK)), with(any(IoBufferEx.class)));
+                oneOf(handler).sessionClosed(with(any(IoSession.class)));
+                then(testState.is("finished"));
+            }
+        });
+        Map<String, Object> connectOptions = new HashMap<>();
+
+        connector.connect("http://localhost:8080/resource", handler, new IoSessionInitializer<ConnectFuture>() {
+            @Override
+            public void initializeSession(IoSession session, ConnectFuture future) {
+                HttpConnectSession connectSession = (HttpConnectSession) session;
+                connectSession.setMethod(GET);
+            }
+        }, connectOptions);
+
+        k3po.finish();
+        syncronizer.waitUntil(testState.is("finished"));
+    }
+
+    @Specification("basic.challenge.twice")
+    @Test
+    public void wontChallengeMoreThenNumberOfAttempts() throws Exception {
+        connector.getConnectOptions().put("http.max.authentication.attempts", "1");
+        final IoHandler handler = context.mock(IoHandler.class);
+        context.checking(new Expectations() {
+            {
+                oneOf(handler).sessionCreated(with(any(IoSession.class)));
+                oneOf(handler).sessionOpened(with(any(IoSession.class)));
+                oneOf(authenticator).getPasswordAuthentication();
+                will(returnValue(new PasswordAuthentication("joe", new char[]{'w', 'e', 'l', 'c', 'o', 'm', 'e'})));
+                oneOf(handler).messageReceived(with(withHttpSessionOfStatus(CLIENT_UNAUTHORIZED)), with(any(IoBufferEx.class)));
+                oneOf(handler).sessionClosed(with(any(IoSession.class)));
+                then(testState.is("finished"));
+            }
+        });
+        Map<String, Object> connectOptions = new HashMap<>();
+
+        connector.connect("http://localhost:8080/resource", handler, new IoSessionInitializer<ConnectFuture>() {
+            @Override
+            public void initializeSession(IoSession session, ConnectFuture future) {
+                HttpConnectSession connectSession = (HttpConnectSession) session;
+                connectSession.setMethod(GET);
+            }
+        }, connectOptions);
+
+        k3po.finish();
+        syncronizer.waitUntil(testState.is("finished"));
+    }
+
+    @Specification("basic.challenge.twice.and.accept")
+    @Test
+    public void willChallengeMultipleAttempts() throws Exception {
+        connector.getConnectOptions().put("http.max.authentication.attempts", "2");
+        final IoHandler handler = context.mock(IoHandler.class);
+        context.checking(new Expectations() {
+            {
+                oneOf(handler).sessionCreated(with(any(IoSession.class)));
+                oneOf(handler).sessionOpened(with(any(IoSession.class)));
+                exactly(2).of(authenticator).getPasswordAuthentication();
+                will(returnValue(new PasswordAuthentication("joe", new char[]{'w', 'e', 'l', 'c', 'o', 'm', 'e'})));
+                oneOf(handler).messageReceived(with(withHttpSessionOfStatus(SUCCESS_OK)), with(any(IoBufferEx.class)));
+                oneOf(handler).sessionClosed(with(any(IoSession.class)));
+                then(testState.is("finished"));
+            }
+        });
+        Map<String, Object> connectOptions = new HashMap<>();
+
+        connector.connect("http://localhost:8080/resource", handler, new IoSessionInitializer<ConnectFuture>() {
+            @Override
+            public void initializeSession(IoSession session, ConnectFuture future) {
+                HttpConnectSession connectSession = (HttpConnectSession) session;
+                connectSession.setMethod(GET);
+            }
+        }, connectOptions);
+
+        k3po.finish();
+        syncronizer.waitUntil(testState.is("finished"));
+    }
+
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/connector/ResetAuthenticatorRule.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/connector/ResetAuthenticatorRule.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.transport.http.security.auth.connector;
+
+import static java.net.Authenticator.setDefault;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ResetAuthenticatorRule implements TestRule {
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                }
+                finally {
+                    setDefault(null);
+                }
+            }
+
+        };
+    }
+
+}

--- a/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/connector/TestAuthenticator.java
+++ b/transport/http/src/test/java/org/kaazing/gateway/transport/http/security/auth/connector/TestAuthenticator.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kaazing.gateway.transport.http.security.auth.connector;
+
+import java.net.Authenticator;
+import java.net.InetAddress;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+
+public class TestAuthenticator extends Authenticator{
+
+    static String host;
+    static int port;
+    static String prompt;
+    static String protocol;
+    static String scheme;
+    static InetAddress site;
+    static URL url;
+    static RequestorType type;
+
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication() {
+         host = this.getRequestingHost();
+         port = this.getRequestingPort();
+         prompt = this.getRequestingPrompt();
+         protocol = this.getRequestingProtocol();
+         scheme = this.getRequestingScheme();
+         site = this.getRequestingSite();
+         url = this.getRequestingURL();
+         type = this.getRequestorType();
+        return new PasswordAuthentication("joe", new char[] {'w', 'e', 'l', 'c', 'o', 'm', 'e'});
+    }
+
+    @Override
+    public String toString() {
+        return "host: " + host + ", " + "port: " + port + ", " + "prompt: " + prompt + ", " + "protocol: " + protocol + ", "
+                + "scheme: " + scheme + ", " + "site: " + site + ", " + "url: " + url + ", " + "type: " + type;
+    }
+}
+

--- a/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/application.challenge.and.accept.rpt
+++ b/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/application.challenge.and.accept.rpt
@@ -1,0 +1,39 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property partialCredentials ${http:loginBase64Encoder("joe")}
+property validCredentials ${http:loginBase64Encoder("joe:welcome")}
+property authHeader ${http:append("Basic ", validCredentials)}
+accept http://localhost:8080/resource
+accepted
+connected
+
+read method "GET"
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Application realm=\"Kaazing Gateway Demo\""
+write header content-length
+write flush
+
+accepted
+connected
+
+read method "GET"
+read header "Authorization" ${authHeader}
+
+write status "200" "OK"
+write header content-length
+write flush

--- a/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.and.accept.rpt
+++ b/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.and.accept.rpt
@@ -1,0 +1,41 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property partialCredentials ${http:loginBase64Encoder("joe")}
+property validCredentials ${http:loginBase64Encoder("joe:welcome")}
+property authHeader ${http:append("Basic ", validCredentials)}
+accept http://localhost:8080/resource
+accepted
+connected
+
+read method "GET"
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Basic realm=\"Kaazing Gateway Demo\""
+write header content-length
+write "not authorized"
+write close
+
+accepted
+connected
+
+read method "GET"
+read header "Authorization" ${authHeader}
+
+write status "200" "OK"
+write header content-length
+write "authorized"
+write close

--- a/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.rpt
+++ b/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.rpt
@@ -1,0 +1,30 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property partialCredentials ${http:loginBase64Encoder("joe")}
+property validCredentials ${http:loginBase64Encoder("joe:welcome")}
+property authHeader ${http:append("Basic ", validCredentials)}
+accept http://localhost:8080/resource
+accepted
+connected
+
+read method "GET"
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Basic realm=\"Kaazing Gateway Demo\""
+write header content-length
+write "Not authorized"
+write flush

--- a/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.twice.and.accept.rpt
+++ b/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.twice.and.accept.rpt
@@ -1,0 +1,53 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property partialCredentials ${http:loginBase64Encoder("joe")}
+property validCredentials ${http:loginBase64Encoder("joe:welcome")}
+property authHeader ${http:append("Basic ", validCredentials)}
+accept http://localhost:8080/resource
+accepted
+connected
+
+read method "GET"
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Basic realm=\"Kaazing Gateway Demo\""
+write header content-length
+write "not authorized"
+write close
+
+accepted
+connected
+
+read method "GET"
+read header "Authorization" ${authHeader}
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Basic realm=\"Kaazing Gateway Demo\""
+write header content-length
+write "not authorized"
+write close
+
+read method "GET"
+read header "Authorization" ${authHeader}
+
+accepted
+connected
+
+write status "200" "OK"
+write header content-length
+write "authorized"
+write close

--- a/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.twice.rpt
+++ b/transport/http/src/test/scripts/org/kaazing/gateway/transport/http/security/auth/connector/basic.challenge.twice.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property partialCredentials ${http:loginBase64Encoder("joe")}
+property validCredentials ${http:loginBase64Encoder("joe:welcome")}
+property authHeader ${http:append("Basic ", validCredentials)}
+accept http://localhost:8080/resource
+accepted
+connected
+
+read method "GET"
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Basic realm=\"Kaazing Gateway Demo\""
+write header content-length
+write "not authorized"
+write close
+
+accepted
+connected
+
+read method "GET"
+read header "Authorization" ${authHeader}
+
+write status "401" "Unauthorized"
+write header "WWW-Authenticate" "Basic realm=\"Kaazing Gateway Demo\""
+write header content-length
+write "not authorized"
+write close

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnAcceptor.java
@@ -1073,7 +1073,7 @@ public class WsnAcceptor extends AbstractBridgeAcceptor<WsnSession, WsnBindings.
                         return;
                     }
 
-                    // If configured with "Application xxx" challenge scheme, reject and close the connection
+//                     If configured with "Application xxx" challenge scheme, reject and close the connection
                     if (!verifyApplicationChallengeSchemeSecurity(session)) {
                         return;
                     }

--- a/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
+++ b/transport/wsn/src/main/java/org/kaazing/gateway/transport/wsn/WsnConnector.java
@@ -174,8 +174,8 @@ public class WsnConnector extends AbstractBridgeConnector<WsnSession> {
 
         // (KG-7391) Use ping and pong to detect and close dead connections, if ws inactivity timeout is active
         final ResourceAddress connectAddress = (ResourceAddress) session.removeAttribute(WSN_CONNECT_ADDRESS_KEY);
-        WsCheckAliveFilter.addIfFeatureEnabled(filterChain, WsnAcceptor.CHECK_ALIVE_FILTER,
-                connectAddress.getOption(WsResourceAddress.INACTIVITY_TIMEOUT), logger);
+//        WsCheckAliveFilter.addIfFeatureEnabled(filterChain, WsnAcceptor.CHECK_ALIVE_FILTER,
+//                connectAddress.getOption(WsResourceAddress.INACTIVITY_TIMEOUT), logger);
     }
 
     @Override

--- a/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/proxy/ResetAuthenticatorRule.java
+++ b/transport/wsn/src/test/java/org/kaazing/gateway/transport/wsn/proxy/ResetAuthenticatorRule.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2007-2016, Kaazing Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kaazing.gateway.transport.wsn.proxy;
+
+import static java.net.Authenticator.setDefault;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ResetAuthenticatorRule implements TestRule {
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                }
+                finally {
+                    setDefault(null);
+                }
+            }
+
+        };
+    }
+
+}

--- a/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeatures.java
+++ b/util/src/main/java/org/kaazing/gateway/util/feature/EarlyAccessFeatures.java
@@ -25,5 +25,7 @@ public interface EarlyAccessFeatures {
     EarlyAccessFeature WSX_302_REDIRECT = new EarlyAccessFeature("wsx.302.redirect", "Send redirect for wsx via 302", false);
     EarlyAccessFeature TURN_REST_SERVICE = new EarlyAccessFeature("turn.rest", "TURN REST Service", false);
     EarlyAccessFeature TURN_PROXY = new EarlyAccessFeature("turn.proxy", "TURN Proxy Service", false);
+    EarlyAccessFeature HTTP_AUTHENTICATOR = new EarlyAccessFeature("http.authenticator", "TURN Proxy Service", false);
+    EarlyAccessFeature LOGIN_MODULE_EXPIRING_STATE = new EarlyAccessFeature("login.module.expiring.state", "TURN Proxy Service", false);
 
 }


### PR DESCRIPTION
2 new features:

The login modules will have an entry in their Login Map with the key "ExpiringState". The value of this entry will be the new public API of ExpiringState class. (Note: Java Doc needs to be public). This ExpiringState class is shared across all Login Modules and GW members in a cluster and can be used to share information across the login modules. (Like one time nonces, or multifactor credentials)

2) The http connector in the gateway can now respond to http challenges on 401 status codes. It will attempt to provide the credentials via a call to the Java Authenticator. The Authenticator is set on the JVM so we don't provide a GW specific way to configuring it and pointing it to related oracle docs on this should be sufficient. (For example Authenticator.setDefault). The http connector will only attempt to authenticate on the HTTP if a new connect-options property is set, Specifically this is "http.max.authentication.attempts" with an integer value. This specifies how many times an http connector will attempt to authenticate when it is challenged. By default this value is 0.
